### PR TITLE
Fix wrong Gamemanager serialize

### DIFF
--- a/src/Options/DesyncOptions.cs
+++ b/src/Options/DesyncOptions.cs
@@ -48,14 +48,7 @@ public static class DesyncOptions
                 foreach (GameLogicComponent com in GameManager.Instance.LogicComponents)
                     if (com.TryCast(out LogicOptions lo))
                     {
-                        if (ConnectionManager.IsVanillaServer) lo.SetGameOptions(options);
-                        else
-                        {
-                            // Custom servers don't like SetGameOptions unfortunately.
-                            if (com.TryCast(out LogicOptionsNormal normalOpt)) normalOpt.GameOptions = options.Cast<NormalGameOptionsV08>();
-                            else if (com.TryCast(out LogicOptionsHnS hnsOpt)) hnsOpt.GameOptions = options.Cast<HideNSeekGameOptionsV08>();
-                            else log.Warn("Option cast failed. Could not set options for host.");
-                        }
+                        lo.SetGameOptions(options);
                     }
             }
             catch (Exception ex)

--- a/src/Patches/GameManagerPatch.cs
+++ b/src/Patches/GameManagerPatch.cs
@@ -1,5 +1,7 @@
 using HarmonyLib;
 using Hazel;
+using Lotus.Extensions;
+using static InnerNet.InnerNetClient;
 
 namespace Lotus.Patches;
 
@@ -12,6 +14,13 @@ class GameManagerSerializeFix
         for (int index = 0; index < __instance.LogicComponents.Count; ++index)
         {
             GameLogicComponent logicComponent = __instance.LogicComponents[index];
+
+            if (!initialState && AmongUsClient.Instance.GameState is GameStates.Started && logicComponent.TryCast(out LogicOptions _))
+            {
+                logicComponent.ClearDirtyFlag();
+                continue;
+            }
+
             if (initialState || logicComponent.IsDirty)
             {
                 flag = true;
@@ -24,17 +33,5 @@ class GameManagerSerializeFix
         __instance.ClearDirtyBits();
         __result = flag;
         return false;
-    }
-}
-[HarmonyPatch(typeof(LogicOptions), nameof(LogicOptions.Serialize))]
-class LogicOptionsSerializePatch
-{
-    public static bool Prefix(LogicOptions __instance, ref bool __result, MessageWriter writer, bool initialState)
-    {
-        // 初回以外はブロックし、CustomSyncSettingsでのみ同期する
-        if (initialState) return true;
-        __result = false;
-        return false;
-
     }
 }


### PR DESCRIPTION
Old code does not prevent LogicOptions from being serialized. It starts a message for LogicOptions and did not write anything in writer, so vanilla client and Impostor can not deserialize the message correctly.

Patching LogicOptions.Serialize won't work, you can't patch LogicOptionsNormal and HnS with this patch.
And it prevents options to be serialized in lobby, causing vanilla players not seeing options updating.
You should patch isDirty or skip serialize like my codes in this pr to make it working properly.

This pr prevents logic options from being serialized mid game and fix the issue Lotus is cooked on custom servers.

I dont know how Lotus determine if is in game so i use AmongUsClient.Instance.GameState is GameStates.Started

