### PR TITLE
Fix Neutral Win Conditions

### DIFF
--- a/src/GameModes/Standard/Conditions/SoloKillingWinCondition.cs
+++ b/src/GameModes/Standard/Conditions/SoloKillingWinCondition.cs
@@ -32,7 +32,7 @@ public class SoloKillingWinCondition : IWinCondition
             if (r.RoleFlags.HasFlag(RoleFlag.CannotWinAlone)) return;
             if (r.RoleAbilityFlags.HasFlag(RoleAbilityFlag.IsAbleToKill)) aliveThatCanKill++;
             if (r.Faction is not Neutral) return;
-            if (!r.MyPlayer.GetVanillaRole().IsImpostor()) return;
+            //if (!r.MyPlayer.GetVanillaRole().IsImpostor()) return;
             aliveKillers.Add(r);
         });
 

--- a/src/Victory/Conditions/VanillaImpostorWin.cs
+++ b/src/Victory/Conditions/VanillaImpostorWin.cs
@@ -33,7 +33,7 @@ public class VanillaImpostorWin : IFactionWinCondition
                 aliveOthers++;
                 if (role.RoleFlags.HasFlag(RoleFlag.CannotWinAlone)) continue;
                 if (role.Faction.Relationship(FactionInstances.Crewmates) is Relation.FullAllies) continue;
-                if (role.MyPlayer.GetVanillaRole().IsImpostor()) aliveKillers++;
+                if (role.MyPlayer.GetVanillaRole().IsImpostor()||role.RoleAbilityFlags.HasFlag(RoleAbilityFlag.IsAbleToKill)) aliveKillers++;
             }
         }
 


### PR DESCRIPTION
Fix it so that Neutral Killers that are *not* an impostor basis:
1. Able to 1v1 Impostors
2. Win on their own