### PR TITLE
Prevent Lotus from overriding Reactor handshake

### DIFF
--- a/ProjectLotus.cs
+++ b/ProjectLotus.cs
@@ -87,6 +87,8 @@ public class ProjectLotus : BasePlugin, IGitVersionEmitter
     public static bool FinishedLoading;
     public const bool AdvancedRoleAssignment = true;
 
+    public static bool HasReactorPlugin;
+
     internal Func<MeetingDelegate, IBlackscreenResolver> GetNewBlackscreenResolver = new(md => new BlackscreenResolver(md));
 
     public ProjectLotus()
@@ -139,6 +141,8 @@ public class ProjectLotus : BasePlugin, IGitVersionEmitter
         GameModeManager = new GameModeManager();
 
         log.Info("GitVersion - " + CurrentVersion);
+
+        HasReactorPlugin = IL2CPPChainloader.Instance.Plugins.ContainsKey("gg.reactor.api");
 
         // Setup, order matters here
 

--- a/src/Patches/Network/ServerAuthPatch.cs
+++ b/src/Patches/Network/ServerAuthPatch.cs
@@ -24,7 +24,11 @@ public class ServerAuthPatch
             log.Debug($"Updating to match new queued lobby type.");
         }
         if (IsLocal) return;
-        __result += Constants.MODDED_REVISION_MODIFIER_VALUE;
+        var revision = __result % 50;
+        if (revision < Constants.MODDED_REVISION_MODIFIER_VALUE)
+        {
+            __result += Constants.MODDED_REVISION_MODIFIER_VALUE;
+        }
     }
 
     [QuickPostfix(typeof(Constants), nameof(Constants.IsVersionModded))]

--- a/src/Server/Patches/ReactorHandshakePatch.cs
+++ b/src/Server/Patches/ReactorHandshakePatch.cs
@@ -83,6 +83,7 @@ public static class ReactorHandshakePatch
     public static void Postfix(ref Il2CppStructArray<byte> __result)
     {
         if (ConnectionManager.IsVanillaServer) return;
+        if (ProjectLotus.HasReactorPlugin) return;
         var handshake = new MessageWriter(1000);
 
         // Original data


### PR DESCRIPTION
This prevents Lotus and Reactor from fighting between who gets the handshake, Reactor already sends all mods, so no regression will happen, i also added a modulo check in broadcast version to prevent scenarios where multiple mods are appending to the broadcast version