### PR TITLE
Add more custom kick messages

### DIFF
--- a/src/GenTranslations/ModerationActionTranslations.cs
+++ b/src/GenTranslations/ModerationActionTranslations.cs
@@ -1,0 +1,12 @@
+﻿using VentLib.Localization.Attributes;
+
+namespace Lotus.GenTranslations;
+
+[Localized("ModerationActions")]
+public class ModerationActionTranslations
+{
+    [Localized("BannedByBanList")] public static string BannedByBanList = "{0} was banned because they are on the host's banlist.";
+    [Localized("NoFriendCode")] public static string NoFriendCode = "{0} was kicked because they do not have a friendcode.";
+    [Localized("MobileDevice")] public static string MobileDevice = "{0} was kicked because they are on a mobile platform.";
+    [Localized("LevelKick")] public static string LevelKick = "{0} was kicked because they do not meet the minimum level requirement.";
+}

--- a/src/GenTranslations/ModerationActionTranslations.cs
+++ b/src/GenTranslations/ModerationActionTranslations.cs
@@ -6,6 +6,7 @@ namespace Lotus.GenTranslations;
 public class ModerationActionTranslations
 {
     [Localized("BannedByBanList")] public static string BannedByBanList = "{0} was banned because they are on the host's banlist.";
+    [Localized("BlockedPlayer")] public static string BlockedPlayer = "{0} was banned because they are blocked by the host.";
     [Localized("NoFriendCode")] public static string NoFriendCode = "{0} was kicked because they do not have a friendcode.";
     [Localized("MobileDevice")] public static string MobileDevice = "{0} was kicked because they are on a mobile platform.";
     [Localized("LevelKick")] public static string LevelKick = "{0} was kicked because they do not meet the minimum level requirement.";

--- a/src/Managers/BanManager.cs
+++ b/src/Managers/BanManager.cs
@@ -60,7 +60,7 @@ public class BanManager
         if (!AmongUsClient.Instance.AmHost) return false;
         if (!CheckBanList(client)) return false;
 
-        string message = string.Format(Localizer.Translate("Messages.BanedByBanList", assembly: Assembly.GetExecutingAssembly()), client.PlayerName);
+        string message = string.Format(Localizer.Translate("ModerationActions.BannedByBanList", assembly: Assembly.GetExecutingAssembly()), client.PlayerName);
 
         LogManager.SendInGame(message);
         AmongUsClient.Instance.KickPlayerWithMessage(player, message, true);

--- a/src/Patches/Actions/FixedUpdatePatch.cs
+++ b/src/Patches/Actions/FixedUpdatePatch.cs
@@ -5,14 +5,8 @@ using Lotus.Extensions;
 using Lotus.Roles.Internals.Enums;
 using Lotus.Roles.Operations;
 using Lotus.Options;
-using VentLib.Utilities;
 using VentLib.Utilities.Debug.Profiling;
-using VentLib.Utilities.Extensions;
 using Lotus.RPC.CustomObjects;
-using System.Linq;
-using System.Reflection;
-using Lotus.Utilities;
-using VentLib.Localization;
 
 namespace Lotus.Patches.Actions;
 
@@ -21,7 +15,6 @@ static class FixedUpdatePatch
 {
     private static readonly StandardLogger log = LoggerFactory.GetLogger<StandardLogger>(typeof(FixedUpdatePatch));
     private static readonly ActionHandle FixedUpdateHandle = ActionHandle.NoInit();
-    private static FixedUpdateLock _levelKickLock = new(1f); // needed to stop excessively long name if kicking player
     private static void Postfix(PlayerControl __instance)
     {
         if (__instance is {PlayerId: 254, notRealPlayer: true}) return;
@@ -29,14 +22,6 @@ static class FixedUpdatePatch
         // DisplayModVersion(__instance);
 
         if (!AmongUsClient.Instance.AmHost) return;
-
-        if (!__instance.IsHost() && Game.State is GameState.InLobby &&
-            __instance.Data.PlayerLevel < GeneralOptions.AdminOptions.KickPlayersUnderLevel &&
-            _levelKickLock.AcquireLock())
-        {
-            AmongUsClient.Instance.KickPlayerWithMessage(__instance, string.Format(Localizer.Translate("ModerationActions.LevelKick", assembly: Assembly.GetExecutingAssembly()), __instance.name));
-            log.Trace($"{__instance.name} was kicked because they are below the minimum level set by the host. ({GeneralOptions.AdminOptions.KickPlayersUnderLevel})");
-        }
 
         if (Game.State is not GameState.Roaming) return;
         bool isLocalPlayer = __instance.PlayerId == PlayerControl.LocalPlayer.PlayerId;

--- a/src/Patches/Actions/FixedUpdatePatch.cs
+++ b/src/Patches/Actions/FixedUpdatePatch.cs
@@ -10,6 +10,9 @@ using VentLib.Utilities.Debug.Profiling;
 using VentLib.Utilities.Extensions;
 using Lotus.RPC.CustomObjects;
 using System.Linq;
+using System.Reflection;
+using Lotus.Utilities;
+using VentLib.Localization;
 
 namespace Lotus.Patches.Actions;
 
@@ -18,6 +21,7 @@ static class FixedUpdatePatch
 {
     private static readonly StandardLogger log = LoggerFactory.GetLogger<StandardLogger>(typeof(FixedUpdatePatch));
     private static readonly ActionHandle FixedUpdateHandle = ActionHandle.NoInit();
+    private static FixedUpdateLock _levelKickLock = new(1f); // needed to stop excessively long name if kicking player
     private static void Postfix(PlayerControl __instance)
     {
         if (__instance is {PlayerId: 254, notRealPlayer: true}) return;
@@ -26,8 +30,13 @@ static class FixedUpdatePatch
 
         if (!AmongUsClient.Instance.AmHost) return;
 
-        if (!__instance.IsHost() && Game.State is GameState.InLobby && __instance.Data.PlayerLevel < GeneralOptions.AdminOptions.KickPlayersUnderLevel)
-            AmongUsClient.Instance.KickPlayer(__instance.GetClientId(), false);
+        if (!__instance.IsHost() && Game.State is GameState.InLobby &&
+            __instance.Data.PlayerLevel < GeneralOptions.AdminOptions.KickPlayersUnderLevel &&
+            _levelKickLock.AcquireLock())
+        {
+            AmongUsClient.Instance.KickPlayerWithMessage(__instance, string.Format(Localizer.Translate("ModerationActions.LevelKick", assembly: Assembly.GetExecutingAssembly()), __instance.name));
+            log.Trace($"{__instance.name} was kicked because they are below the minimum level set by the host. ({GeneralOptions.AdminOptions.KickPlayersUnderLevel})");
+        }
 
         if (Game.State is not GameState.Roaming) return;
         bool isLocalPlayer = __instance.PlayerId == PlayerControl.LocalPlayer.PlayerId;

--- a/src/Patches/Network/PlayerJoinPatch.cs
+++ b/src/Patches/Network/PlayerJoinPatch.cs
@@ -1,15 +1,20 @@
 using System;
+using System.Reflection;
 using HarmonyLib;
 using InnerNet;
 using Lotus.API.Odyssey;
 using Lotus.API.Reactive;
 using Lotus.API.Reactive.HookEvents;
+using Lotus.Extensions;
 using Lotus.Logging;
 using Lotus.Managers;
+using Lotus.Network;
 using Lotus.Utilities;
 using Lotus.Options;
+using VentLib.Localization;
 using VentLib.Utilities;
 using VentLib.Utilities.Attributes;
+using VentLib.Utilities.Extensions;
 using VentLib.Utilities.Harmony.Attributes;
 using xCloud;
 using static Platforms;
@@ -54,14 +59,19 @@ public class PlayerJoinPatch
 
         client.PlayerName = playerName;
         player.name = playerName;
-        bool kickPlayer = false;
-        kickPlayer = kickPlayer || GeneralOptions.AdminOptions.KickPlayersWithoutFriendcodes && client.FriendCode == "" && AmongUsClient.Instance.NetworkMode is not NetworkModes.LocalGame;
-        kickPlayer = kickPlayer || client.PlatformData.Platform is Android or IPhone && GeneralOptions.AdminOptions.KickMobilePlayers;
 
-        if (kickPlayer)
+        if (GeneralOptions.AdminOptions.KickPlayersWithoutFriendcodes && client.FriendCode == "" &&
+            AmongUsClient.Instance.NetworkMode is not NetworkModes.LocalGame && ConnectionManager.IsVanillaServer)
         {
-            log.Trace($"{playerName} was kicked because one of the kick options are on in the Admin Settings area.");
-            AmongUsClient.Instance.KickPlayer(client.Id, false);
+            log.Trace($"{playerName} was kicked because they do not have a friendcode.");
+            AmongUsClient.Instance.KickPlayerWithMessage(player, string.Format(Localizer.Translate("ModerationActions.NoFriendCode"), playerName));
+            return;
+        }
+
+        if (client.PlatformData.Platform is Android or IPhone && GeneralOptions.AdminOptions.KickMobilePlayers)
+        {
+            log.Trace($"{playerName} was kicked because they are on a mobile platform.");
+            AmongUsClient.Instance.KickPlayerWithMessage(player, string.Format(Localizer.Translate("ModerationActions.MobileDevice"), playerName));
             return;
         }
 

--- a/src/Patches/Network/PlayerJoinPatch.cs
+++ b/src/Patches/Network/PlayerJoinPatch.cs
@@ -37,11 +37,6 @@ public class PlayerJoinPatch
     public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ClientData client)
     {
         log.Trace($"{client.PlayerName} (ClientID={client.Id}) (Platform={client.PlatformData.Platform}) (FriendCode={client.FriendCode}) joined the game.", "Session");
-        if (DestroyableSingleton<FriendsListManager>.Instance.IsPlayerBlockedUsername(client.FriendCode) && AmongUsClient.Instance.AmHost)
-        {
-            AmongUsClient.Instance.KickPlayer(client.Id, true);
-            log.Info($"ブロック済みのプレイヤー{client.PlayerName}({client.FriendCode})をBANしました。", "BAN");
-        }
 
         string playerName = client.PlayerName;
 
@@ -72,6 +67,21 @@ public class PlayerJoinPatch
         {
             log.Trace($"{playerName} was kicked because they are on a mobile platform.");
             AmongUsClient.Instance.KickPlayerWithMessage(player, string.Format(Localizer.Translate("ModerationActions.MobileDevice"), playerName));
+            return;
+        }
+
+        if (!player.IsHost() && Game.State is GameState.InLobby &&
+            client.PlayerLevel < GeneralOptions.AdminOptions.KickPlayersUnderLevel)
+        {
+            AmongUsClient.Instance.KickPlayerWithMessage(player, string.Format(Localizer.Translate("ModerationActions.LevelKick"), playerName));
+            log.Trace($"{playerName} was kicked because they are below the minimum level set by the host. ({GeneralOptions.AdminOptions.KickPlayersUnderLevel})");
+            return;
+        }
+
+        if (DestroyableSingleton<FriendsListManager>.Instance.IsPlayerBlockedUsername(client.FriendCode) && AmongUsClient.Instance.AmHost)
+        {
+            PluginDataManager.BanManager.BanWithReason(player, "Blocked by host in vanilla Among Us friends list.", string.Format(Localizer.Translate("ModerationActions.BlockedPlayer")));
+            log.Trace($"{client.PlayerName} ({client.FriendCode}) was banned because they are blocked by the host in the vanilla Among Us friends list.");
             return;
         }
 


### PR DESCRIPTION
Adds custom kick messages for more cases: https://discord.com/channels/1017870413545607209/1364827985311694868
- Player joining has no friend code
  - (also made it so that this does not apply on modded regions)
<img width="444" height="87" alt="image" src="https://github.com/user-attachments/assets/0020706d-5577-4703-bc6e-3132a0bcd335" />

<br />
- Player joining is on a mobile device
<img width="441" height="87" alt="image" src="https://github.com/user-attachments/assets/8dea4bb5-3b98-4d41-83f7-fe051e7a636d" />

<br />
- Player joining does not meet minimum level requirement
<img width="408" height="56" alt="image" src="https://github.com/user-attachments/assets/b85e2be8-7e5e-414e-8bf4-5fd9437c8d42" />
<br />
- Player is blocked by the host in the Vanilla AU Friends List
<img width="324" height="77" alt="image" src="https://github.com/user-attachments/assets/f0c7b20b-51b6-4400-a964-22ab51bfd8f6" />


<br />
also fixed an issue where <code>Messages.BanedByBanList</code> would show up when a player on your banlist tries to join since the entry never generated in the lang file
<img width="454" height="61" alt="image" src="https://github.com/user-attachments/assets/236ef3ea-ae67-49f5-ab7b-b6656ffa5afd" />
