### PR TITLE
Fix in-game mod updater

### DIFF
--- a/src/GUI/Components/UpdateComponent.cs
+++ b/src/GUI/Components/UpdateComponent.cs
@@ -29,9 +29,9 @@ public class UpdateComponent : MonoBehaviour
         UpdateProgressBar.transform.localScale -= new Vector3(0.4f, 0.3f);
         UpdateProgressBar.gameObject.SetActive(false);
 
-        GameObject updateButtonObject = gameObject.CreateChild("Update Button", new Vector3(0.32f, 1.8f));
+        GameObject updateButtonObject = gameObject.CreateChild("Update Button", new Vector3(1.1f, 1.9f));
         UpdateButton = updateButtonObject.AddComponent<MonoToggleButton>();
-        UpdateButton.transform.localScale -= new Vector3(0.5f, 0.5f);
+        UpdateButton.transform.localScale -= new Vector3(0.4f, 0.7f);
         UpdateButton.SetOffText("V1.30.218");
         UpdateButton.SetToggleOnAction(DoUpdate);
     }

--- a/src/GUI/Menus/ModUpdateMenu.cs
+++ b/src/GUI/Menus/ModUpdateMenu.cs
@@ -7,6 +7,7 @@ using Lotus.GUI.Menus.OptionsMenu.Components;
 using Lotus.GUI.Patches;
 using Lotus.Utilities;
 using TMPro;
+using Twitch;
 using UnityEngine;
 using VentLib.Localization.Attributes;
 using VentLib.Utilities.Attributes;
@@ -24,6 +25,7 @@ public class ModUpdateMenu : MonoBehaviour
 
     public SpriteRenderer background;
     public TextMeshPro Header;
+    public GameObject ClickBlocker;
 
     public MonoToggleButton ContinueButton;
     public GameObject AnchorObject;
@@ -33,21 +35,31 @@ public class ModUpdateMenu : MonoBehaviour
 
     public ModUpdateMenu(IntPtr intPtr) : base(intPtr)
     {
-        AnchorObject = gameObject.CreateChild("Anchor");
+        AnchorObject = gameObject.CreateChild("ModUpdateMenu");
         AnchorObject.transform.localPosition = new Vector3(0f, 0f, -2f);
-        background = AnchorObject.AddComponent<SpriteRenderer>();
+        background = AnchorObject.CreateChild("Background").AddComponent<SpriteRenderer>();
         background.sprite = OptionMenuResources.ModUpdaterBackgroundSprite;
+        background.transform.localScale = new Vector3(2f, 2f);
 
-        GameObject headerGameObject = AnchorObject.CreateChild("Header", new Vector3(8.7f, -0.2f));
+        GameObject headerGameObject = AnchorObject.CreateChild("Header", new Vector3(8.7f, -0.6f));
         Header = headerGameObject.AddComponent<TextMeshPro>();
         Header.font = CustomOptionContainer.GetGeneralFont();
         Header.fontSize = 3f;
 
-        GameObject continueObject = AnchorObject.CreateChild("Continue", new Vector3(1.22f, -1.5f));
+        GameObject continueObject = AnchorObject.CreateChild("Continue", new Vector3(2.12f, -0.9f));
         ContinueButton = continueObject.AddComponent<MonoToggleButton>();
         ContinueButton.SetOffText(ModUpdateMenuTranslations.CloseText);
         ContinueButton.SetToggleOnAction(ProcessClose);
         ContinueButton.gameObject.SetActive(false);
+
+        if (TwitchManager.InstanceExists) // should always exist on main menu but just in case
+        {
+            GameObject blockerOriginal = TwitchManager.Instance.TwitchPopup.gameObject.transform.Find("BackroundIgnore").gameObject;
+
+            ClickBlocker = Instantiate(blockerOriginal, AnchorObject.transform);
+            ClickBlocker.transform.localPosition = new Vector3(0f, 0f, 1f);
+        }
+
         AnchorObject.SetActive(false);
 
         log.Trace($"Update ready during Mod Menu Creation: {SplashPatch.UpdateReady}", "ModUpdateMenu");
@@ -109,7 +121,7 @@ public class ModUpdateMenu : MonoBehaviour
         component.UpdateText.text = item.Name;
         component.UpdateButton.SetOffText(item.Version ?? ModUpdateMenuTranslations.UpdateText);
         component.UpdateAction = item.UpdateFunction;
-        component.transform.localPosition -= new Vector3(0f, 0.3f * offset);
+        component.transform.localPosition += new Vector3(0.5f, -0.6f * (offset + 1));
         item.Loaded = true;
         item.UpdateComponent = component;
         if (item.AutoStartUpdate) component.UpdateButton.SetState(true);
@@ -181,6 +193,9 @@ public class ModUpdateMenu : MonoBehaviour
 
         [Localized(nameof(UpdateAvailableText))]
         public static string UpdateAvailableText = "Updates Available!";
+
+        [Localized(nameof(UpdatesFoundText))]
+        public static string UpdatesFoundText = "Updates Found!";
     }
 }
 

--- a/src/GUI/Patches/SplashPatch.cs
+++ b/src/GUI/Patches/SplashPatch.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using HarmonyLib;
-using Lotus.Utilities;
 using Lotus.Extensions;
 using Lotus.GUI.Menus;
 using Lotus.Logging;
@@ -13,8 +12,9 @@ using VentLib.Utilities.Extensions;
 using VentLib.Utilities.Harmony.Attributes;
 using VentLib.Utilities.Optionals;
 using Object = UnityEngine.Object;
-using System.Collections;
-using BepInEx.Unity.IL2CPP.Utils.Collections;
+using UnityEngine.Events;
+using UnityEngine.UI;
+using VentLib.Localization;
 
 namespace Lotus.GUI.Patches;
 
@@ -414,32 +414,30 @@ class SplashPatch
         PlayerParticles particles = Object.FindObjectOfType<PlayerParticles>();
         particles.gameObject.SetActive(false);
 
-        DevLogger.Log("Skipping mod update menu as it breaks the game.");
-
-        // ModUpdateMenu = __instance.gameObject.AddComponent<ModUpdateMenu>();
-        // ModUpdateMenu.AnchorObject.transform.localPosition += new Vector3(0f, 0f, -9f);
+        ModUpdateMenu = __instance.gameObject.AddComponent<ModUpdateMenu>();
+        ModUpdateMenu.AnchorObject.transform.localPosition += new Vector3(0f, 0f, -9f);
 
         DevLogger.Log("?????c");
 
 
-        /*GameObject updateButton = Object.Instantiate(playLocalButton, __instance.transform);*/
-        /*Async.Schedule(() =>
+        GameObject updateButton = Object.Instantiate(playLocalButton, playLocalButton.transform.parent).gameObject;
+        updateButton.name = "UpdateButton";
+        Async.Schedule(() =>
         {
             TextMeshPro tmp = updateButton.GetComponentInChildren<TextMeshPro>();
-            tmp.text = "Update Found!";
+            tmp.text = Localizer.Translate("GUI.ModUpdateMenu.UpdatesFoundText");
             tmp.enableWordWrapping = true;
         }, 0.1f);
-        updateButton.transform.localPosition += new Vector3(0f, 1.85f);
-        updateButton.transform.localScale -= new Vector3(0f, 0.25f);
-        updateButton.GetComponentInChildren<ButtonRolloverHandler>().OutColor = ModConstants.Palette.GeneralColor5;
+        updateButton.transform.localPosition = new Vector3(3.2f, -1.05f);
+        updateButton.transform.localScale = new Vector3(0.7f, 0.8f);
         updateButton.GetComponentInChildren<SpriteRenderer>().color = ModConstants.Palette.GeneralColor5;
         Button.ButtonClickedEvent buttonClickedEvent = new();
         updateButton.GetComponentInChildren<PassiveButton>().OnClick = buttonClickedEvent;
-        buttonClickedEvent.AddListener((UnityAction)(Action)(() => ModUpdateMenu.Open()));*/
+        buttonClickedEvent.AddListener((UnityAction)(Action)(() => ModUpdateMenu.Open()));
 
-        /*UpdateButton = UnityOptional<GameObject>.Of(updateButton);
+        UpdateButton = UnityOptional<GameObject>.Of(updateButton);
 
-        if (!ProjectLotus.ModUpdater.HasUpdate) updateButton.gameObject.SetActive(false);*/
+        if (!ProjectLotus.ModUpdater.HasUpdate) updateButton.gameObject.SetActive(false);
         FriendsListManager.Instance.StopPolling();
         FriendsListManager.Instance.OnSignOut();
     }


### PR DESCRIPTION
This PR fixes the issue which caused the in-game mod updater to break the main menu, as well as re-laying out the mod updater to fit the new assets it was given a few years ago.

**Preview Screenshots:**
<img width="1118" height="627" alt="image" src="https://github.com/user-attachments/assets/40e75de7-4ea6-4f48-814d-d1333993c245" />

---
<img width="1919" height="1079" alt="Screenshot 2026-07-16 054315" src="https://github.com/user-attachments/assets/25b238fc-1467-44e8-b211-890dba17d147" />

---
<img width="1919" height="1079" alt="Screenshot 2026-07-16 054343" src="https://github.com/user-attachments/assets/ce968c2a-e4b6-4dd6-ae4e-51ee861b048c" />
