### PR TITLE
Improve Discord Presence

### DIFF
--- a/src/Discord/Patches/DiscordPresencePatch.cs
+++ b/src/Discord/Patches/DiscordPresencePatch.cs
@@ -1,15 +1,68 @@
+using AmongUs.Data;
 using HarmonyLib;
 using Discord;
+using InnerNet;
+using Lotus.API.Odyssey;
+using Lotus.Network;
+using UnityEngine;
 
 namespace Lotus.Discord.Patches;
 
 [HarmonyPatch(typeof(ActivityManager), nameof(ActivityManager.UpdateActivity))]
 public class DiscordPatch
 {
-    public static string DiscordMessage = "Project Lotus " + (ProjectLotus.DevVersion ? ProjectLotus.DevVersionStr : "v" + ProjectLotus.VisibleVersion);
+    private static string _details = "";
+    private static string _state = "";
+
+    private static string _gameCode = "";
+    private static string _gameRegion = "";
+
     public static void Prefix(ref Activity activity)
     {
-        if (string.IsNullOrEmpty(activity.Details)) activity.Details = DiscordMessage;
-        else activity.Details += $" ({DiscordMessage})";
+        activity.Assets = new ActivityAssets
+        {
+            LargeImage = "https://avatars.githubusercontent.com/u/173427715?s=1400&v=4",
+            LargeText = $"{ProjectLotus.ModName}" + (ProjectLotus.DevVersion ? $" v{ProjectLotus.CompileVersion} [DEV]" : "v" + ProjectLotus.VisibleVersion),
+            SmallImage = "https://lotusau.top/lilypad/rpc_icon.png",
+            SmallText = $"Among Us v{GetVersion()}",
+        };
+
+        string details = $"{ProjectLotus.ModName} " + (ProjectLotus.DevVersion ? ProjectLotus.DevVersionStr : $"v{ProjectLotus.VisibleVersion}");
+        string state = activity.State;
+
+        bool inMenuOrFreeplay = activity.State is "In Menus" or "In Freeplay";
+        bool disabled = DataManager.Settings.Gameplay.StreamerMode;
+
+        if (!disabled && !inMenuOrFreeplay && AmongUsClient.Instance.GameId != 32)
+        {
+            string gameCode = GameCode.IntToGameName(AmongUsClient.Instance.GameId);
+            string gameRegion = ConnectionManager.GetRegionAbbreviation(ServerManager.Instance.CurrentRegion.Name);
+
+            details = $"Lotus v{ProjectLotus.VisibleVersion}";
+            if (gameCode != "" || gameRegion != "")
+                details += $" - ({gameCode}) | ({gameRegion})";
+
+            state = GetStateMessage(Game.State);
+            if (Game.State is not GameState.InLobby)
+                state += $" - ({GameData.Instance.PlayerCount}/{GameManager.Instance.LogicOptions.MaxPlayers})";
+        }
+
+        activity.Details = details;
+
+        if (!disabled)
+            activity.State = state;
     }
+
+    private static string GetStateMessage(GameState state)
+    {
+        return state switch
+        {
+            GameState.Roaming => $"Roaming {(MapNames)ProjectLotus.NormalOptions.MapId}",
+            GameState.InIntro => $"Roaming {(MapNames)ProjectLotus.NormalOptions.MapId}",
+            GameState.InLobby => "Waiting in Lobby",
+            _ => "Idle"
+        };
+    }
+
+    private static string GetVersion() => ReferenceDataManager.Instance?.Refdata?.userFacingVersion ?? Application.version;
 }

--- a/src/Network/ConnectionManager.cs
+++ b/src/Network/ConnectionManager.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Hazel;
 using Hazel.Udp;
 using InnerNet;
@@ -47,5 +49,40 @@ public class ConnectionManager
                    regionInfo.PingServer.EndsWith(Domain, System.StringComparison.Ordinal) &&
                    regionInfo.Servers.All(serverInfo => serverInfo.Ip.EndsWith(Domain, System.StringComparison.Ordinal));
         }
+    }
+
+
+    public static string GetRegionAbbreviation(string region) // everyone ships different names for the same regions
+    {
+        if (string.IsNullOrEmpty(region)) return region;
+
+        Regex NikoRegionRegex = new(@"(?:\(|-)([^)-]+)\)?$", RegexOptions.Compiled);
+
+        if (region.StartsWith("Modded ", StringComparison.OrdinalIgnoreCase)) // normal modded regions
+        {
+            var idx = region.IndexOf("(M", StringComparison.OrdinalIgnoreCase);
+            if (idx >= 0 && region.EndsWith(')'))
+                return region[(idx + 1)..^1];
+
+            if (region.Contains("North America", StringComparison.OrdinalIgnoreCase) || region.EndsWith("NA", StringComparison.OrdinalIgnoreCase)) return "MNA";
+            if (region.Contains("Europe", StringComparison.OrdinalIgnoreCase) || region.EndsWith("EU", StringComparison.OrdinalIgnoreCase)) return "MEU";
+            if (region.Contains("Asia", StringComparison.OrdinalIgnoreCase) || region.EndsWith("AS", StringComparison.OrdinalIgnoreCase)) return "MAS";
+
+            return region;
+        }
+
+        if (region.StartsWith("Niko", StringComparison.OrdinalIgnoreCase)) // niko regions
+        {
+            var match = NikoRegionRegex.Match(region);
+            return match.Success ? $"Niko{match.Groups[1].Value}" : region;
+        }
+
+        return region switch // vanilla/innersloth regions
+        {
+            "North America" => "NA",
+            "Europe" => "EU",
+            "Asia" => "AS",
+            _ => region
+        };
     }
 }


### PR DESCRIPTION
This PR refactors the Discord Presence which Lotus adds to be more similar to other mods.

There is now custom branding for the icon, as well as showing more information about the lobby you are currently in (player count, what map you're roaming, game code & region). This can be disabled by enabling Streamer Mode.

Also adds ConnectionManager.GetRegionAbbreviation since most region websites display regions in different ways. Also, I wasn't sure where the method fit better, there or somewhere else

### Preview Images:
---
<img width="290" height="138" alt="Screenshot 2026-07-18 043052" src="https://github.com/user-attachments/assets/aa9a3518-5dce-4e5d-8415-e0e40fee16fd" /><br>
---
<img width="298" height="124" alt="Screenshot 2026-07-18 043102" src="https://github.com/user-attachments/assets/54e8b042-1d88-4cf2-aeb7-cc22ff2b43d1" /><br>
---
<img width="290" height="140" alt="Screenshot 2026-07-18 043129" src="https://github.com/user-attachments/assets/14426a48-f7c3-4912-9a47-dded118136f4" /><br>
---
<img width="292" height="126" alt="Screenshot 2026-07-18 043144" src="https://github.com/user-attachments/assets/14450db9-bec4-4291-b4aa-af2dc0ea0e1b" /><br>
